### PR TITLE
Fixes #59:  saving edits no longer requires two clicks

### DIFF
--- a/assets/js/controllers/reviewCtrl.js
+++ b/assets/js/controllers/reviewCtrl.js
@@ -1,6 +1,6 @@
 "use strict";
 
-angular.module("DocApp").controller("ReviewCtrl", function($scope, $document, $location, $routeParams, $q, $window, CommentFactory, DocFactory, SegmentFactory, TeamFactory, UserFactory) {
+angular.module("DocApp").controller("ReviewCtrl", function($scope, $document, $location, $routeParams, $q, $window, BoolServices, CommentFactory, DocFactory, SegmentFactory, TeamFactory, UserFactory) {
 
   const loggedInUid = firebase.auth().currentUser.uid;
   const thisDocID = $routeParams.doc_id;
@@ -9,15 +9,6 @@ angular.module("DocApp").controller("ReviewCtrl", function($scope, $document, $l
   let loggedInDisplayName, overwriteText, toCheck, updatedText;
 
 ////// INTERNAL FUNCTIONS
-
-////// Checks whether passed in property is not undefined
-  const checkUndefined = prop => typeof prop !== "undefined";
-
-////// Checks whether segment has uid_temp & whether the temp
-    // edit is the current user's
-  const checkUidTemp = ({uid_temp}) =>
-    checkUndefined(uid_temp) && uid_temp === loggedInUid;
-
   const reprint = () =>
     SegmentFactory.getSegments(thisDocID)
     .then(segments => $scope.segments = segments)
@@ -180,12 +171,12 @@ angular.module("DocApp").controller("ReviewCtrl", function($scope, $document, $l
       toCheck = $scope.segments[originalSegmentIdx].classes;
     // Passes when user changes text of a green highlighted 'added'
     // segment, updating the suggestion
-      if (checkUndefined(toCheck) && toCheck.includes("added")) {
+      if (BoolServices.hasClass(toCheck, "added")) {
         updateEditSuggestion(id);
 
     // Passes when user changes text of a red highlight 'deleted'
     // segment, overwriting the previous edit suggestion
-      } else if (checkUndefined(toCheck) && toCheck.includes("deleted")) {
+  } else if (BoolServices.hasClass(toCheck, "deleted")) {
         overwriteEditSuggestion(id, originalSegmentIdx);
 
     // Passes when a user changes text of an original, unmodified
@@ -311,7 +302,7 @@ angular.module("DocApp").controller("ReviewCtrl", function($scope, $document, $l
   $scope.activateReviewBox = segment => {
 
     // Passes if clicked on segment is "commented"
-    if (checkUndefined(segment.classes) && segment.classes.includes("commented")) {
+    if (BoolServices.hasClass(segment.classes, "commented")) {
     // Gets the comment from the database
       CommentFactory.getComment(segment.firebaseID)
       .then(comment => {
@@ -333,7 +324,7 @@ angular.module("DocApp").controller("ReviewCtrl", function($scope, $document, $l
       )
       .catch(err => console.log(err));
     // Passes if the clicked on segment is "added" or "deleted"
-    } else if (checkUndefined(segment.classes) && !segment.classes.includes("commented")) {
+  } else if (BoolServices.notUndefined(segment.classes) && !BoolServices.hasClass(segment.classes, "commented")) {
       $scope.showWrapper =
         $scope.showWrapper && $scope.reviewItem.text === segment.text ? false : true;
 
@@ -351,7 +342,7 @@ angular.module("DocApp").controller("ReviewCtrl", function($scope, $document, $l
     let newReviewText =
       document.getElementById("updatedReviewText").innerHTML;
 
-    if ($scope.reviewItem.text !== newReviewText && classCheck.includes("commented")) {
+    if ($scope.reviewItem.text !== newReviewText && BoolServices.hasClass(classCheck, "commented")) {
       // Patches with new comment text & uid, does not check for uid since
       // that would be extraneous
       CommentFactory.patchComment(
@@ -365,7 +356,7 @@ angular.module("DocApp").controller("ReviewCtrl", function($scope, $document, $l
       .then(({displayName}) => $scope.reviewItem.displayName = displayName)
       .catch(err => console.log(err));
 
-    } else if ($scope.reviewItem.text !== newReviewText && classCheck.includes("deleted")) {
+    } else if ($scope.reviewItem.text !== newReviewText && BoolServices.hasClass(classCheck, "deleted")) {
 
       let idx =
         $scope.segments.findIndex(segment => $scope.reviewItem.firebaseID === segment.firebaseID);
@@ -374,7 +365,7 @@ angular.module("DocApp").controller("ReviewCtrl", function($scope, $document, $l
 
       $scope.reviewItem.text = newReviewText;
 
-    } else if ($scope.reviewItem.text !== newReviewText && classCheck.includes("added")) {
+    } else if ($scope.reviewItem.text !== newReviewText && BoolServices.hasClass(classCheck, "added")) {
 
       updateEditSuggestion($scope.reviewItem.firebaseID, "updatedReviewText");
       $scope.reviewItem.text = newReviewText;

--- a/assets/js/controllers/reviewCtrl.js
+++ b/assets/js/controllers/reviewCtrl.js
@@ -1,6 +1,6 @@
 "use strict";
 
-angular.module("DocApp").controller("ReviewCtrl", function($scope, $document, $location, $routeParams, $window, CommentFactory, DocFactory, SegmentFactory, TeamFactory, UserFactory) {
+angular.module("DocApp").controller("ReviewCtrl", function($scope, $document, $location, $routeParams, $q, $window, CommentFactory, DocFactory, SegmentFactory, TeamFactory, UserFactory) {
 
   const loggedInUid = firebase.auth().currentUser.uid;
   const thisDocID = $routeParams.doc_id;
@@ -49,7 +49,7 @@ angular.module("DocApp").controller("ReviewCtrl", function($scope, $document, $l
         ));
       }
 
-      return Promise.all(promises);
+      return $q.all(promises);
     });
 
 ////// Creates new edit suggestion, updating old segment with 'deleted', posting
@@ -75,7 +75,7 @@ angular.module("DocApp").controller("ReviewCtrl", function($scope, $document, $l
       })
     );
 
-    Promise.all(promises)
+    $q.all(promises)
     .then(() => {
       let promises = [];
     // Updates the original segment with class 'deleted', pushing the
@@ -97,16 +97,11 @@ angular.module("DocApp").controller("ReviewCtrl", function($scope, $document, $l
         ));
       }
 
-      return Promise.all(promises);
+      return $q.all(promises);
     })
     // Gets updated data and reprints to the DOM
     .then(() => SegmentFactory.getSegments(thisDocID))
-    .then(segments => {
-      $scope.segments = segments;
-    // Fix for user needing to click twice away from segment to get
-    // update to print to DOM
-      $scope.$apply();
-    })
+    .then(segments => $scope.segments = segments)
     .catch(err => console.log(err));
   };
 
@@ -296,7 +291,7 @@ angular.module("DocApp").controller("ReviewCtrl", function($scope, $document, $l
         ));
       }
 
-      return Promise.all(promises);
+      return $q.all(promises);
     })
     // Reprints segments after getting them
     .then(() => SegmentFactory.getSegments(thisDocID))

--- a/assets/js/controllers/reviewCtrl.js
+++ b/assets/js/controllers/reviewCtrl.js
@@ -18,6 +18,11 @@ angular.module("DocApp").controller("ReviewCtrl", function($scope, $document, $l
   const checkUidTemp = ({uid_temp}) =>
     checkUndefined(uid_temp) && uid_temp === loggedInUid;
 
+  const reprint = () =>
+    SegmentFactory.getSegments(thisDocID)
+    .then(segments => $scope.segments = segments)
+    .catch(err => console.log(err));
+
 ////// Removes temporary edits from the database; passing in 'true' means to
     // reset segments to their unedited status, passing in 'false' means to
     // remove the temporary status of suggested edits
@@ -110,8 +115,7 @@ angular.module("DocApp").controller("ReviewCtrl", function($scope, $document, $l
     optionalID ? document.getElementById(optionalID).innerHTML.trim() : document.getElementById(id).innerHTML.trim();
 
     SegmentFactory.patchSegment(id, {text: updatedText})
-    .then(() => SegmentFactory.getSegments(thisDocID))
-    .then(segments => $scope.segments = segments);
+    .then(() => reprint());
   };
 
   const overwriteEditSuggestion = (id, idx) => {
@@ -119,8 +123,7 @@ angular.module("DocApp").controller("ReviewCtrl", function($scope, $document, $l
     overwriteText = document.getElementById(id).innerHTML.trim();
 
     SegmentFactory.patchSegment(suggestionSegment.firebaseID, {text: overwriteText})
-    .then(() => SegmentFactory.getSegments(thisDocID))
-    .then(segments => $scope.segments = segments);
+    .then(() => reprint());
   };
 
 ////// PARTIAL-FACING FUNCTIONS
@@ -402,8 +405,6 @@ angular.module("DocApp").controller("ReviewCtrl", function($scope, $document, $l
   .then(userData => {
     $scope.doc.displayName = userData.displayName;
     // Get document segments
-    return SegmentFactory.getSegments(thisDocID);
-  })
-  .then(segments => $scope.segments = segments)
-  .catch(err => console.log(err));
+    return reprint();
+  });
 });

--- a/assets/js/controllers/reviewCtrl.js
+++ b/assets/js/controllers/reviewCtrl.js
@@ -101,7 +101,12 @@ angular.module("DocApp").controller("ReviewCtrl", function($scope, $document, $l
     })
     // Gets updated data and reprints to the DOM
     .then(() => SegmentFactory.getSegments(thisDocID))
-    .then(segments => $scope.segments = segments)
+    .then(segments => {
+      $scope.segments = segments;
+    // Fix for user needing to click twice away from segment to get
+    // update to print to DOM
+      $scope.$apply();
+    })
     .catch(err => console.log(err));
   };
 
@@ -243,7 +248,6 @@ angular.module("DocApp").controller("ReviewCtrl", function($scope, $document, $l
     // If the original segment has a 'classes' property AND is the string
     // being commented upon
         if ($scope.segments[originalSegmentIdx].hasOwnProperty("classes") && newSegments[i].text === sel.toString()) {
-          console.log("condition 1 passed");
     // Split the original segments 'classes' string into an array
           newSegments[i].classes = $scope.segments[originalSegmentIdx].classes.split(' ');
     // Adds the "commented" class to that 'classes' array
@@ -260,7 +264,6 @@ angular.module("DocApp").controller("ReviewCtrl", function($scope, $document, $l
           );
     // If the original segment has a 'classes' property
         } else if ($scope.segments[originalSegmentIdx].hasOwnProperty("classes")) {
-            console.log("condition 2 passed");
     // Adds 'classes' property from the original segment
             newSegments[i].classes = $scope.segments[originalSegmentIdx].classes.split(' ');
     // (5) Pushes that new segment to Promise.all(promises)

--- a/assets/js/services/boolServices.js
+++ b/assets/js/services/boolServices.js
@@ -1,0 +1,17 @@
+"use strict";
+
+angular.module("DocApp").service('BoolServices', function() {
+////// Checks whether passed in property is not undefined
+  const notUndefined = property => typeof property !== "undefined";
+
+////// Checks whether array of classes has the class passed in
+  const hasClass = (arrayOfClasses, classToCheck) =>
+    notUndefined(arrayOfClasses) && arrayOfClasses.includes(classToCheck);
+
+////// Checks whether segment has uid_temp & whether the temp
+    // edit is the current user's
+  const isUidTemp = (uid_temp, uid) =>
+    notUndefined(uid_temp) && uid_temp === uid;
+
+  return {hasClass, notUndefined, isUidTemp};
+});

--- a/assets/partials/all-docs.html
+++ b/assets/partials/all-docs.html
@@ -1,6 +1,3 @@
-<div>
-  {{test}}
-</div>
 <h3>
   {{team.displayName}}
 </h3>

--- a/assets/partials/new-doc.html
+++ b/assets/partials/new-doc.html
@@ -1,6 +1,3 @@
-<div>
-  {{test}}
-</div>
 <h3>{{team.displayName}}</h3>
 <div>
   <button type="button" name="submit" ng-click="saveDoc()">Submit</button>

--- a/assets/partials/team-login.html
+++ b/assets/partials/team-login.html
@@ -1,7 +1,4 @@
 <div>
-  {{test}}
-</div>
-<div>
   <input type="search" ng-model="searchTerm" placeholder="Search for a team">
 </div>
 <div>

--- a/assets/partials/team-register.html
+++ b/assets/partials/team-register.html
@@ -1,7 +1,4 @@
 <div>
-  {{test}}
-</div>
-<div>
   <input type="text" name="team-name" ng-model="team.displayName" placeholder="Enter Team Name">
   <input type="password" name="password" ng-model="team.password" placeholder="Enter password">
   <input type="password" name="reenter" ng-model="reenter" placeholder="Reenter password">


### PR DESCRIPTION
### Features
- Uses `$q.all()` to resolve #59
- Moves various checks generating booleans to `BoolServices`
### Misc.
- Round of DRYing code up, including new `reprint()`
### New Files
- `services/boolServices.js`

### Issues
Fixes #59